### PR TITLE
Modify edge weight in denoise process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,6 @@ OBJS = main.o
 deps := $(OBJS:%.o=%.o.d)
 
 %.o: %.c
-	@echo "$(ENABLE_OPENMP)"
 	$(CC) -o $@ $(CFLAGS) -c -MMD -MF $@.d $<
 main: $(THIRD_PARTIES) $(OBJS)
 	$(CC) -o $@ $(OBJS) $(LDFLAGS)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 CC ?= gcc
 CFLAGS = -Wall -O2
 LDFLAGS = -lm
+ENABLE_OPENMP = 0
 
 ifeq ("$(ENABLE_OPENMP)","1")
 CFLAGS += -DOPT_PLANE -march=native -fopenmp
@@ -20,6 +21,7 @@ OBJS = main.o
 deps := $(OBJS:%.o=%.o.d)
 
 %.o: %.c
+	@echo "$(ENABLE_OPENMP)"
 	$(CC) -o $@ $(CFLAGS) -c -MMD -MF $@.d $<
 main: $(THIRD_PARTIES) $(OBJS)
 	$(CC) -o $@ $(OBJS) $(LDFLAGS)


### PR DESCRIPTION
1. In the `Makefile`, I add the variable `ENABLE_OPENMP` to enable parallelization.
2. In the `denoise` function of `main.c`,  `edge` is assigned the value CLAMP2BYTE(diff). 
`int edge = CLAMP2BYTE(diff);`
 If `diff` < 0, `edge` is assigned 0. However, the condition `diff` < 0 indicates that current pixel is near the lighter side of an edge. If this kind of `diff` is directly discarded, the light edge won't be preserved. Take the absolute value of this kind of `diff` can solve this kind of problem.
`int edge = CLAMP2BYTE(myabs(diff));`

> myabs() is the function for computing absolute value.

3. In the `denoise` function of `main.c`, we can reorder the computation of `var`.
From 
`int var = (prev_sum_pow - mean*prev_sum) / window_size;` 
to
`int var = prev_sum_pow / window_size - mean*mean;`
This modification takes advantage of pre-calculated `mean` and gain performance in non-parallel version.